### PR TITLE
feat(corporate): add corporate reports page + notification bell; polish layout

### DIFF
--- a/client/src/components/Corporate/CorporateDash.jsx
+++ b/client/src/components/Corporate/CorporateDash.jsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react'
 import { Routes, Route, NavLink, Outlet, Link, useParams } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import { PieChart, Pie, Cell, Tooltip, Legend, BarChart, Bar, XAxis, YAxis, ResponsiveContainer, LineChart, Line, CartesianGrid } from 'recharts'
+import CorporateReports from "./Corporate/CorporateReports";
 
 // Single-file bundle of the CSR dashboard UI (layout + pages + data)
 // Drop-in usage: import DashboardBundle from './dashboard/DashboardBundle';
@@ -56,53 +57,36 @@ const NGO_LIST = [
   },
 ]
 
-function Breadcrumb({ items }){
-  return (
-    <nav className="flex items-center space-x-2 text-sm mb-6">
-      <Link to="/dashboard" className="text-gray-500 hover:text-gray-700 transition-colors">Company Portal</Link>
-      {items.map((item, i)=> (
-        <div key={i} className="flex items-center space-x-2">
-          <span className="text-gray-400">/</span>
-          {item.href ? (
-            <Link to={item.href} className="text-gray-500 hover:text-gray-700 transition-colors">{item.label}</Link>
-          ) : (
-            <span className="font-medium" style={{color:'var(--text-primary-color)'}}>{item.label}</span>
-          )}
-        </div>
-      ))}
-    </nav>
-  )
-}
 
-function StatCard({ label, value, color, icon }){
+function StatCard({ label, value, color, icon }) {
   return (
     <div className="card-base p-5">
       <div className="flex items-center gap-3 mb-2">
-        <div className="w-10 h-10 rounded-lg flex items-center justify-center text-xl" style={{background:`${color}20`}}>{icon}</div>
-        <div className="text-2xl font-bold" style={{color:'var(--text-primary-color)'}}>{value}</div>
+        <div className="w-10 h-10 rounded-lg flex items-center justify-center text-xl" style={{ background: `${color}20` }}>{icon}</div>
+        <div className="text-2xl font-bold" style={{ color: 'var(--text-primary-color)' }}>{value}</div>
       </div>
-      <div className="text-sm" style={{color:'var(--text-secondary-color)'}}>{label}</div>
+      <div className="text-sm" style={{ color: 'var(--text-secondary-color)' }}>{label}</div>
     </div>
   )
 }
 
-function RecentActivity(){
-  const ITEMS=[
-    { id:1, text:'You sent a request to Seva Foundation', time:'2 hours ago', icon:'➕' },
-    { id:2, text:'Shiksha Trust accepted your connection', time:'Yesterday', icon:'✔️' },
-    { id:3, text:'Prakriti Collective updated a project', time:'2 days ago', icon:'🔄' },
+function RecentActivity() {
+  const ITEMS = [
+    { id: 1, text: 'You sent a request to Seva Foundation', time: '2 hours ago', icon: '➕' },
+    { id: 2, text: 'Shiksha Trust accepted your connection', time: 'Yesterday', icon: '✔️' },
+    { id: 3, text: 'Prakriti Collective updated a project', time: '2 days ago', icon: '🔄' },
   ]
   return (
     <div className="card-base p-5">
-      <div className="flex items-center gap-2 mb-4"><span className="text-lg">ℹ️</span><div className="font-semibold" style={{color:'var(--text-primary-color)'}}>Recent Activity</div></div>
+      <div className="flex items-center gap-2 mb-4"><span className="text-lg">ℹ️</span><div className="font-semibold" style={{ color: 'var(--text-primary-color)' }}>Recent Activity</div></div>
       <div className="relative">
-        <div className="absolute left-4 top-0 bottom-0 w-0.5" style={{background:'var(--border-color)'}} />
+        <div className="absolute left-4 top-0 bottom-0 w-0.5" style={{ background: 'var(--border-color)' }} />
         <ul className="space-y-4">
-          {ITEMS.map(i=> (
+          {ITEMS.map(i => (
             <li key={i.id} className="flex items-start gap-4 relative">
-              <div className="w-8 h-8 rounded-full flex items-center justify-center text-sm relative z-10" style={{background:'var(--card-background-color)',border:'2px solid var(--border-color)'}}>{i.icon}</div>
+              <div className="w-8 h-8 rounded-full flex items-center justify-center text-sm relative z-10" style={{ background: 'var(--card-background-color)', border: '2px solid var(--border-color)' }}>{i.icon}</div>
               <div>
-                <div className="text-sm" style={{color:'var(--text-secondary-color)'}}>{i.text}</div>
+                <div className="text-sm" style={{ color: 'var(--text-secondary-color)' }}>{i.text}</div>
                 <div className="text-xs text-gray-400 mt-1">{i.time}</div>
               </div>
             </li>
@@ -113,17 +97,17 @@ function RecentActivity(){
   )
 }
 
-function DonutChart(){
-  const data=[
-    { name:'Education', value:40 },
-    { name:'Healthcare', value:30 },
-    { name:'Environment', value:20 },
-    { name:'Others', value:10 },
+function DonutChart() {
+  const data = [
+    { name: 'Education', value: 40 },
+    { name: 'Healthcare', value: 30 },
+    { name: 'Environment', value: 20 },
+    { name: 'Others', value: 10 },
   ]
-  const COLORS=['var(--primary-color)','var(--accent-color)','#f59e0b','#ef4444']
+  const COLORS = ['var(--primary-color)', 'var(--accent-color)', '#f59e0b', '#ef4444']
   return (
     <div className="card-base p-5">
-      <div className="font-semibold mb-3" style={{color:'var(--text-primary-color)'}}>Investment by Focus Area</div>
+      <div className="font-semibold mb-3" style={{ color: 'var(--text-primary-color)' }}>Investment by Focus Area</div>
       <div className="w-full h-72">
         <ResponsiveContainer>
           <PieChart>
@@ -142,42 +126,43 @@ function DonutChart(){
 }
 
 // ---------- Layout ----------
-function DashboardLayout(){
-  const navItems=[
-    { label:'Dashboard', to:'/dashboard' },
-    { label:'Discover NGOs', to:'/dashboard/discover' },
-    { label:'My Requests', to:'/dashboard/requests' },
-    { label:'Reports', to:'/dashboard/reports' },
-    { label:'My Profile', to:'/dashboard/profile' },
-  ]
+function DashboardLayout() {
+  const navItems = [
+    { label: 'Dashboard', to: '/dashboard' },
+    { label: 'Discover NGOs', to: '/dashboard/discover' },
+    { label: 'My Requests', to: '/dashboard/requests' },
+    { label: 'Reports', to: '/dashboard/reports' },
+    { label: 'My Profile', to: '/dashboard/profile' },
+  ];
+
   return (
-    <div className="min-h-screen dashboard-theme" style={{background:'var(--background-color)'}}>
+    <div className="min-h-screen dashboard-theme" style={{ background: 'var(--background-color)' }}>
       <div className="flex min-h-screen">
-        <aside className="hidden md:block w-[260px] rounded-r-2xl" style={{background:'#ffffff',color:'#495057',borderRight:'1px solid var(--border-color)'}}>
-          <div className="h-16 flex items-center px-5 border-b" style={{borderColor:'var(--border-color)'}}>
-            <div className="text-xl font-bold" style={{color:'#172b4d'}}><span className="brand-gradient">CSR</span> Connect</div>
+        <aside className="hidden md:block w-[260px] rounded-r-2xl" style={{ background: '#ffffff', color: '#495057', borderRight: '1px solid var(--border-color)' }}>
+          <div className="h-16 flex items-center px-5 border-b" style={{ borderColor: 'var(--border-color)' }}>
+            <div className="text-xl font-bold" style={{ color: '#172b4d' }}><span className="brand-gradient">CSR</span> Connect</div>
           </div>
           <nav className="py-4">
             <ul className="px-3 space-y-1">
               {navItems.map(item => (
                 <li key={item.to}>
-                  <NavLink to={item.to} end={item.to==='/dashboard'} className={({isActive}) => `sidebar-link flex items-center gap-3 px-4 py-2 rounded-md no-underline transition-all ${isActive?'accent-bar bg-gray-100':'hover:bg-gray-100'}`} style={({isActive})=>({color:isActive?'#172b4d':'#495057'})}>
-                    <span className="text-sm font-medium" style={{opacity:1}}>{item.label}</span>
+                  <NavLink to={item.to} end={item.to === '/dashboard'} className={({ isActive }) => `sidebar-link flex items-center gap-3 px-4 py-2 rounded-md no-underline transition-all ${isActive ? 'accent-bar bg-gray-100' : 'hover:bg-gray-100'}`} style={({ isActive }) => ({ color: isActive ? '#172b4d' : '#495057' })}>
+                    <span className="text-sm font-medium" style={{ opacity: 1 }}>{item.label}</span>
                   </NavLink>
                 </li>
               ))}
             </ul>
           </nav>
           <div className="mt-auto p-4 hidden xl:block">
-            <div className="rounded-lg border p-3 text-xs" style={{borderColor:'var(--border-color)',color:'#495057',background:'#ffffff'}}>Empowering impactful CSR partnerships.</div>
+            <div className="rounded-lg border p-3 text-xs" style={{ borderColor: 'var(--border-color)', color: '#495057', background: '#ffffff' }}>Empowering impactful CSR partnerships.</div>
           </div>
         </aside>
 
         <div className="flex-1 min-w-0">
           <header className="navbar-enhanced flex items-center px-4 md:px-6 justify-between">
             <div className="hidden md:block">
-              <div className="text-lg font-bold" style={{color:'var(--text-primary-color)'}}><span className="brand-gradient">CSR</span> Connect Dashboard</div>
-              <div className="text-xs" style={{color:'var(--text-secondary-color)'}}>Company Portal</div>
+              <div className="text-lg font-bold" style={{ color: 'var(--text-primary-color)' }}><span className="brand-gradient">CSR</span> Connect Dashboard</div>
+              <div className="text-xs" style={{ color: 'var(--text-secondary-color)' }}>Company Portal</div>
             </div>
           </header>
           <main className="p-0 md:p-6">
@@ -190,15 +175,15 @@ function DashboardLayout(){
 }
 
 // ---------- Pages ----------
-function DashboardHome(){
-  const stats=[
-    { label:'Pending Requests', value:4, color:'#f59e0b', icon:'📩' },
-    { label:'Active Partnerships', value:12, color:'#10b981', icon:'🤝' },
-    { label:'Total Investment', value:'₹ 2.4 Cr', color:'#6366f1', icon:'💰' },
+function DashboardHome() {
+  const stats = [
+    { label: 'Pending Requests', value: 4, color: '#f59e0b', icon: '📩' },
+    { label: 'Active Partnerships', value: 12, color: '#10b981', icon: '🤝' },
+    { label: 'Total Investment', value: '₹ 2.4 Cr', color: '#6366f1', icon: '💰' },
   ]
   return (
     <div className="space-y-6 px-8 pt-8 pb-10">
-      <Breadcrumb items={[{label:'Dashboard'}]} />
+      <Breadcrumb items={[{ label: 'Dashboard' }]} />
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         {stats.map(s => <StatCard key={s.label} {...s} />)}
       </div>
@@ -210,7 +195,7 @@ function DashboardHome(){
   )
 }
 
-function Discover(){
+function Discover() {
   const [search, setSearch] = useState('')
   const [focusFilter, setFocusFilter] = useState('')
   const [verifiedOnly, setVerifiedOnly] = useState(false)
@@ -247,24 +232,24 @@ function Discover(){
     <div className="space-y-6 px-8 pt-8 pb-10">
       <Breadcrumb items={[{ label: 'Discover NGOs' }]} />
       <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
-        <motion.div initial={{opacity:0,x:-20}} animate={{opacity:1,x:0}} transition={{duration:.5}} className="lg:col-span-1 card-base p-6" style={{borderColor:'var(--border-color)'}}>
-          <div className="flex items-center gap-2 mb-4"><span className="text-lg">🔍</span><div className="font-semibold" style={{color:'var(--text-primary-color)'}}>Filters</div></div>
+        <motion.div initial={{ opacity: 0, x: -20 }} animate={{ opacity: 1, x: 0 }} transition={{ duration: .5 }} className="lg:col-span-1 card-base p-6" style={{ borderColor: 'var(--border-color)' }}>
+          <div className="flex items-center gap-2 mb-4"><span className="text-lg">🔍</span><div className="font-semibold" style={{ color: 'var(--text-primary-color)' }}>Filters</div></div>
           <div className="space-y-4">
             <div>
-              <label className="flex items-center gap-2 text-sm font-medium mb-2" style={{color:'var(--text-secondary-color)'}}><span>🔍</span> Search</label>
-              <input value={search} onChange={e=>setSearch(e.target.value)} placeholder="Search by name, location, or tagline" className="w-full rounded-lg border px-3 py-2" style={{borderColor:'var(--border-color)'}} />
+              <label className="flex items-center gap-2 text-sm font-medium mb-2" style={{ color: 'var(--text-secondary-color)' }}><span>🔍</span> Search</label>
+              <input value={search} onChange={e => setSearch(e.target.value)} placeholder="Search by name, location, or tagline" className="w-full rounded-lg border px-3 py-2" style={{ borderColor: 'var(--border-color)' }} />
             </div>
             <div>
-              <label className="flex items-center gap-2 text-sm font-medium mb-2" style={{color:'var(--text-secondary-color)'}}><span>🎯</span> Focus Area</label>
-              <select value={focusFilter} onChange={e=>setFocusFilter(e.target.value)} className="w-full rounded-lg border px-3 py-2 bg-white" style={{borderColor:'var(--border-color)'}}>
+              <label className="flex items-center gap-2 text-sm font-medium mb-2" style={{ color: 'var(--text-secondary-color)' }}><span>🎯</span> Focus Area</label>
+              <select value={focusFilter} onChange={e => setFocusFilter(e.target.value)} className="w-full rounded-lg border px-3 py-2 bg-white" style={{ borderColor: 'var(--border-color)' }}>
                 <option value="">All Focus Areas</option>
                 {allTags.map(t => <option key={t} value={t}>{t}</option>)}
               </select>
             </div>
             <div>
-              <label className="flex items-center gap-2 select-none"><input type="checkbox" checked={verifiedOnly} onChange={e=>setVerifiedOnly(e.target.checked)} className="rounded" /><span className="text-sm" style={{color:'var(--text-secondary-color)'}}>✅ Verified only</span></label>
+              <label className="flex items-center gap-2 select-none"><input type="checkbox" checked={verifiedOnly} onChange={e => setVerifiedOnly(e.target.checked)} className="rounded" /><span className="text-sm" style={{ color: 'var(--text-secondary-color)' }}>✅ Verified only</span></label>
             </div>
-            <button onClick={()=>{setSearch('');setFocusFilter('');setVerifiedOnly(false)}} className="btn-primary-g w-full rounded-lg px-4 py-2 text-sm font-medium">Clear All Filters</button>
+            <button onClick={() => { setSearch(''); setFocusFilter(''); setVerifiedOnly(false) }} className="btn-primary-g w-full rounded-lg px-4 py-2 text-sm font-medium">Clear All Filters</button>
           </div>
         </motion.div>
         <div className="lg:col-span-3">
@@ -273,14 +258,14 @@ function Discover(){
               <h1 className="page-title"><span className="brand-gradient">Discover</span> NGOs</h1>
               <p className="page-subtext">Find authentic NGOs making real impact</p>
             </div>
-            <div className="text-sm" style={{color:'var(--text-secondary-color)'}}>{filtered.length} NGO{filtered.length!==1?'s':''} found</div>
+            <div className="text-sm" style={{ color: 'var(--text-secondary-color)' }}>{filtered.length} NGO{filtered.length !== 1 ? 's' : ''} found</div>
           </div>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
             {filtered.map((ngo, index) => (
-              <motion.div key={ngo.id} initial={{opacity:0,y:20}} animate={{opacity:1,y:0}} transition={{duration:.5, delay:index*0.1}} className="card-base overflow-hidden group hover:scale-105 transition-all duration-300 min-h-[520px] flex flex-col">
+              <motion.div key={ngo.id} initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: .5, delay: index * 0.1 }} className="card-base overflow-hidden group hover:scale-105 transition-all duration-300 min-h-[520px] flex flex-col">
                 <div className="relative w-full overflow-hidden">
                   <img src={getNgoImage(ngo.focusAreas)} alt={`${ngo.focusAreas[0]} NGO`} className="w-full h-48 object-cover rounded-xl shadow-sm group-hover:scale-110 transition-transform duration-300" />
-                  <div className="absolute inset-0 rounded-xl" style={{background:'linear-gradient(to top, var(--primary-color), transparent)', opacity:0.25}} />
+                  <div className="absolute inset-0 rounded-xl" style={{ background: 'linear-gradient(to top, var(--primary-color), transparent)', opacity: 0.25 }} />
                 </div>
                 <div className="p-5 flex-1 flex flex-col">
                   <div className="flex items-start justify-between mb-3">
@@ -291,14 +276,14 @@ function Discover(){
                         <div className="page-subtext">Location: {ngo.location}</div>
                       </div>
                     </div>
-                    <span className={`text-xs px-3 py-1 rounded-full font-medium ${ngo.verified?'bg-green-100 text-green-700':'bg-gray-200 text-gray-700'}`}>{ngo.verified?'✅ Verified':'⚠️ Unverified'}</span>
+                    <span className={`text-xs px-3 py-1 rounded-full font-medium ${ngo.verified ? 'bg-green-100 text-green-700' : 'bg-gray-200 text-gray-700'}`}>{ngo.verified ? '✅ Verified' : '⚠️ Unverified'}</span>
                   </div>
                   <p className="card-text mb-4">{ngo.tagline}</p>
                   <div className="flex flex-wrap gap-2 mb-4">
                     {ngo.focusAreas.map(tag => <span key={tag} className="text-xs px-2 py-1 rounded-md font-medium bg-gray-100 text-gray-700">{tag}</span>)}
                   </div>
                   <div className="mt-auto flex items-center justify-between">
-                    <div className="text-xs" style={{color:'var(--text-secondary-color)'}}>Impact Score: 4.5⭐</div>
+                    <div className="text-xs" style={{ color: 'var(--text-secondary-color)' }}>Impact Score: 4.5⭐</div>
                     <Link to={`/dashboard/ngo/${ngo.id}`} className="btn-primary-g px-4 py-2 rounded-lg text-sm font-medium no-underline">View Profile</Link>
                   </div>
                 </div>
@@ -311,11 +296,11 @@ function Discover(){
   )
 }
 
-function NgoProfile(){
+function NgoProfile() {
   const { ngoId } = useParams()
   const [tab, setTab] = useState('about')
   const [showToast, setShowToast] = useState(false)
-  const ngo = useMemo(()=> NGO_LIST.find(n => n.id===ngoId), [ngoId])
+  const ngo = useMemo(() => NGO_LIST.find(n => n.id === ngoId), [ngoId])
 
   const getNgoImage = (focusAreas) => {
     if (!focusAreas) return 'https://images.unsplash.com/photo-1455849318743-b2233052fcff?q=80&w=1600&auto=format&fit=crop'
@@ -330,9 +315,9 @@ function NgoProfile(){
 
   return (
     <div className="space-y-6 px-8 pt-8 pb-10">
-      <div className="rounded-xl overflow-hidden relative" style={{height:200}}>
+      <div className="rounded-xl overflow-hidden relative" style={{ height: 200 }}>
         <img src={getNgoImage(ngo.focusAreas)} alt="hero" className="w-full h-full object-cover" />
-        <div className="absolute inset-0" style={{background:'linear-gradient(to top, var(--primary-color), transparent)', opacity:0.25}} />
+        <div className="absolute inset-0" style={{ background: 'linear-gradient(to top, var(--primary-color), transparent)', opacity: 0.25 }} />
         <div className="absolute inset-0 bg-black/25" />
         <div className="absolute left-5 bottom-5 flex items-center gap-4">
           {ngo.logo && <img src={ngo.logo} alt="logo" className="w-16 h-16 rounded-lg object-cover border-4 border-white" />}
@@ -342,17 +327,17 @@ function NgoProfile(){
           </div>
         </div>
         <div className="absolute right-5 bottom-5">
-          <button onClick={()=>{setShowToast(true); setTimeout(()=>setShowToast(false), 2200)}} className="no-underline btn-primary-g px-4 py-2 rounded-md text-sm">Connect</button>
+          <button onClick={() => { setShowToast(true); setTimeout(() => setShowToast(false), 2200) }} className="no-underline btn-primary-g px-4 py-2 rounded-md text-sm">Connect</button>
         </div>
       </div>
       <div className="card-base">
         <div className="border-b border-gray-200 flex">
-          {['about','projects'].map(k => (
-            <button key={k} onClick={()=>setTab(k)} className={`px-4 py-2 text-sm font-medium -mb-px border-b-2 ${tab===k?'border-emerald-600 text-emerald-700':'border-transparent text-gray-500 hover:text-gray-700'}`}>{k==='about'?'Overview':'Projects'}</button>
+          {['about', 'projects'].map(k => (
+            <button key={k} onClick={() => setTab(k)} className={`px-4 py-2 text-sm font-medium -mb-px border-b-2 ${tab === k ? 'border-emerald-600 text-emerald-700' : 'border-transparent text-gray-500 hover:text-gray-700'}`}>{k === 'about' ? 'Overview' : 'Projects'}</button>
           ))}
         </div>
         <div className="p-5">
-          {tab==='about' ? (
+          {tab === 'about' ? (
             <div className="space-y-4">
               <p className="text-gray-700 text-sm leading-6">{ngo.description}</p>
               <div className="text-sm"><div className="text-gray-500">Contact</div><div className="text-gray-800">{ngo.contact.email} • {ngo.contact.phone}</div></div>
@@ -375,24 +360,24 @@ function NgoProfile(){
         </div>
       </div>
       {showToast && (
-        <div className="fixed right-4 bottom-6 z-50"><div className="btn-primary-g px-4 py-3 rounded-lg shadow-lg text-white text-sm" style={{boxShadow:'0 8px 25px rgba(0,0,0,0.15)'}}>Connection Request Sent</div></div>
+        <div className="fixed right-4 bottom-6 z-50"><div className="btn-primary-g px-4 py-3 rounded-lg shadow-lg text-white text-sm" style={{ boxShadow: '0 8px 25px rgba(0,0,0,0.15)' }}>Connection Request Sent</div></div>
       )}
     </div>
   )
 }
 
-function Requests(){
-  const DATA=[
-    { id:1, ngo:'Seva Foundation', logo:'/images/logo2.jpg', date:'2025-01-10', status:'Pending', focusAreas:['Healthcare','Women Empowerment'], amount:'₹ 15,00,000', description:'Mobile Health Clinics for Rural Areas' },
-    { id:2, ngo:'Shiksha Trust', logo:'/images/logo3.jpg', date:'2025-01-07', status:'Accepted', focusAreas:['Education','Digital Literacy'], amount:'₹ 25,00,000', description:'Smart Classroom Program' },
-    { id:3, ngo:'Prakriti Collective', logo:'/images/logo.jpg', date:'2025-01-05', status:'Declined', focusAreas:['Environment','Water'], amount:'₹ 8,00,000', description:'Stepwell Restoration Project' },
+function Requests() {
+  const DATA = [
+    { id: 1, ngo: 'Seva Foundation', logo: '/images/logo2.jpg', date: '2025-01-10', status: 'Pending', focusAreas: ['Healthcare', 'Women Empowerment'], amount: '₹ 15,00,000', description: 'Mobile Health Clinics for Rural Areas' },
+    { id: 2, ngo: 'Shiksha Trust', logo: '/images/logo3.jpg', date: '2025-01-07', status: 'Accepted', focusAreas: ['Education', 'Digital Literacy'], amount: '₹ 25,00,000', description: 'Smart Classroom Program' },
+    { id: 3, ngo: 'Prakriti Collective', logo: '/images/logo.jpg', date: '2025-01-05', status: 'Declined', focusAreas: ['Environment', 'Water'], amount: '₹ 8,00,000', description: 'Stepwell Restoration Project' },
   ]
   const [activeTab, setActiveTab] = useState('All')
   const tabs = ['All', 'Pending', 'Accepted', 'Declined']
-  const filtered = activeTab==='All'? DATA : DATA.filter(d=>d.status===activeTab)
-  const getTimeAgo = (d)=> '2 days ago'
-  const getStatusColor = (s)=> s==='Pending'?'bg-yellow-100 text-yellow-800 border-yellow-200': s==='Accepted'?'bg-green-100 text-green-700 border-green-200':'bg-red-100 text-red-700 border-red-200'
-  const getStatusIcon = (s)=> s==='Pending'?'⏳': s==='Accepted'?'✅':'❌'
+  const filtered = activeTab === 'All' ? DATA : DATA.filter(d => d.status === activeTab)
+  const getTimeAgo = (d) => '2 days ago'
+  const getStatusColor = (s) => s === 'Pending' ? 'bg-yellow-100 text-yellow-800 border-yellow-200' : s === 'Accepted' ? 'bg-green-100 text-green-700 border-green-200' : 'bg-red-100 text-red-700 border-red-200'
+  const getStatusIcon = (s) => s === 'Pending' ? '⏳' : s === 'Accepted' ? '✅' : '❌'
   return (
     <div className="space-y-6 px-8 pt-8 pb-10">
       <Breadcrumb items={[{ label: 'My Requests' }]} />
@@ -400,7 +385,7 @@ function Requests(){
         <div className="border-b border-gray-200">
           <div className="flex gap-1 px-6 pt-4">
             {tabs.map(tab => (
-              <button key={tab} onClick={()=>setActiveTab(tab)} className={`px-4 py-3 text-sm font-medium transition-all relative ${activeTab===tab?'text-white':'text-gray-500 hover:text-gray-700'}`} style={{background: activeTab===tab? 'linear-gradient(135deg,var(--primary-color),var(--secondary-color))':'transparent'}}>
+              <button key={tab} onClick={() => setActiveTab(tab)} className={`px-4 py-3 text-sm font-medium transition-all relative ${activeTab === tab ? 'text-white' : 'text-gray-500 hover:text-gray-700'}`} style={{ background: activeTab === tab ? 'linear-gradient(135deg,var(--primary-color),var(--secondary-color))' : 'transparent' }}>
                 <span className="relative z-10">{tab}</span>
               </button>
             ))}
@@ -414,18 +399,18 @@ function Requests(){
                   <div className="flex items-center gap-3">
                     <img src={item.logo} alt={item.ngo} className="w-12 h-12 rounded-lg object-cover" />
                     <div>
-                      <div className="font-semibold" style={{color:'var(--text-primary-color)'}}>{item.ngo}</div>
-                      <div className="text-sm" style={{color:'var(--text-secondary-color)'}}>{item.description}</div>
+                      <div className="font-semibold" style={{ color: 'var(--text-primary-color)' }}>{item.ngo}</div>
+                      <div className="text-sm" style={{ color: 'var(--text-secondary-color)' }}>{item.description}</div>
                     </div>
                   </div>
                   <span className={`text-xs px-3 py-1 rounded-full font-medium border ${getStatusColor(item.status)}`}>{getStatusIcon(item.status)} {item.status}</span>
                 </div>
                 <div className="flex flex-wrap gap-2 mb-3">
-                  {item.focusAreas.map(a=> <span key={a} className="text-xs px-2 py-1 rounded-md bg-gray-100 text-gray-700">{a}</span>)}
+                  {item.focusAreas.map(a => <span key={a} className="text-xs px-2 py-1 rounded-md bg-gray-100 text-gray-700">{a}</span>)}
                 </div>
                 <div className="flex items-center justify-between text-sm">
-                  <div style={{color:'var(--text-secondary-color)'}}>Requested {getTimeAgo(item.date)}</div>
-                  <div className="font-medium" style={{color:'var(--text-primary-color)'}}>{item.amount}</div>
+                  <div style={{ color: 'var(--text-secondary-color)' }}>Requested {getTimeAgo(item.date)}</div>
+                  <div className="font-medium" style={{ color: 'var(--text-primary-color)' }}>{item.amount}</div>
                 </div>
               </div>
             ))}
@@ -436,54 +421,54 @@ function Requests(){
   )
 }
 
-function Reports(){
-  const TABLE=[{ ngo:'Seva Foundation', projects:5, funds:85 },{ ngo:'Shiksha Trust', projects:7, funds:120 },{ ngo:'Prakriti Collective', projects:3, funds:40 }]
-  const MONTHLY=[{ month:'Jan', funds:18 },{ month:'Feb', funds:22 },{ month:'Mar', funds:15 },{ month:'Apr', funds:28 },{ month:'May', funds:24 },{ month:'Jun', funds:30 }]
-  const totalFunds=TABLE.reduce((a,b)=>a+b.funds,0)
+function Reports() {
+  const TABLE = [{ ngo: 'Seva Foundation', projects: 5, funds: 85 }, { ngo: 'Shiksha Trust', projects: 7, funds: 120 }, { ngo: 'Prakriti Collective', projects: 3, funds: 40 }]
+  const MONTHLY = [{ month: 'Jan', funds: 18 }, { month: 'Feb', funds: 22 }, { month: 'Mar', funds: 15 }, { month: 'Apr', funds: 28 }, { month: 'May', funds: 24 }, { month: 'Jun', funds: 30 }]
+  const totalFunds = TABLE.reduce((a, b) => a + b.funds, 0)
   return (
     <div className="space-y-6 px-8 pt-8 pb-10">
       <Breadcrumb items={[{ label: 'Reports & Analytics' }]} />
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <div className="card-base p-5"><div className="font-semibold mb-3" style={{color:'var(--text-primary-color)'}}>Investment by Focus Area</div><div className="w-full h-72"><ResponsiveContainer><PieChart><Pie data={[{name:'Education',value:40},{name:'Healthcare',value:30},{name:'Environment',value:20},{name:'Others',value:10}]} dataKey="value" nameKey="name" outerRadius={100} innerRadius={60}><Cell fill="var(--primary-color)" /><Cell fill="var(--accent-color)" /><Cell fill="#f59e0b" /><Cell fill="#ef4444" /></Pie><Tooltip /><Legend /></PieChart></ResponsiveContainer></div></div>
-        <div className="card-base p-5"><div className="font-semibold mb-3" style={{color:'var(--text-primary-color)'}}>Monthly CSR Spending (₹ Lakh)</div><div className="w-full h-72"><ResponsiveContainer><BarChart data={MONTHLY}><CartesianGrid strokeDasharray="3 3" /><XAxis dataKey="month" /><YAxis /><Tooltip /><Bar dataKey="funds" fill="var(--primary-color)" radius={[6,6,0,0]} /></BarChart></ResponsiveContainer></div></div>
+        <div className="card-base p-5"><div className="font-semibold mb-3" style={{ color: 'var(--text-primary-color)' }}>Investment by Focus Area</div><div className="w-full h-72"><ResponsiveContainer><PieChart><Pie data={[{ name: 'Education', value: 40 }, { name: 'Healthcare', value: 30 }, { name: 'Environment', value: 20 }, { name: 'Others', value: 10 }]} dataKey="value" nameKey="name" outerRadius={100} innerRadius={60}><Cell fill="var(--primary-color)" /><Cell fill="var(--accent-color)" /><Cell fill="#f59e0b" /><Cell fill="#ef4444" /></Pie><Tooltip /><Legend /></PieChart></ResponsiveContainer></div></div>
+        <div className="card-base p-5"><div className="font-semibold mb-3" style={{ color: 'var(--text-primary-color)' }}>Monthly CSR Spending (₹ Lakh)</div><div className="w-full h-72"><ResponsiveContainer><BarChart data={MONTHLY}><CartesianGrid strokeDasharray="3 3" /><XAxis dataKey="month" /><YAxis /><Tooltip /><Bar dataKey="funds" fill="var(--primary-color)" radius={[6, 6, 0, 0]} /></BarChart></ResponsiveContainer></div></div>
       </div>
-      <div className="card-base p-5"><div className="font-semibold mb-3" style={{color:'var(--text-primary-color)'}}>Partnership Growth Over Time</div><div className="w-full h-72"><ResponsiveContainer><LineChart data={MONTHLY}><CartesianGrid strokeDasharray="3 3" /><XAxis dataKey="month" /><YAxis /><Tooltip /><Line type="monotone" dataKey="funds" stroke="var(--accent-color)" strokeWidth={2} dot={{r:3}} /></LineChart></ResponsiveContainer></div></div>
-      <div className="card-base p-4"><table className="w-full text-sm"><thead><tr className="text-left" style={{color:'var(--text-primary-color)'}}><th className="py-2">NGO</th><th>Projects</th><th>Funds (₹ Lakh)</th></tr></thead><tbody>{TABLE.map((r,idx)=> <tr key={r.ngo} className={idx%2?'bg-gray-50':''}><td className="py-2">{r.ngo}</td><td>{r.projects}</td><td>{r.funds}</td></tr>)}</tbody><tfoot><tr><td className="py-2 font-medium">Total</td><td></td><td>{totalFunds}</td></tr></tfoot></table></div>
+      <div className="card-base p-5"><div className="font-semibold mb-3" style={{ color: 'var(--text-primary-color)' }}>Partnership Growth Over Time</div><div className="w-full h-72"><ResponsiveContainer><LineChart data={MONTHLY}><CartesianGrid strokeDasharray="3 3" /><XAxis dataKey="month" /><YAxis /><Tooltip /><Line type="monotone" dataKey="funds" stroke="var(--accent-color)" strokeWidth={2} dot={{ r: 3 }} /></LineChart></ResponsiveContainer></div></div>
+      <div className="card-base p-4"><table className="w-full text-sm"><thead><tr className="text-left" style={{ color: 'var(--text-primary-color)' }}><th className="py-2">NGO</th><th>Projects</th><th>Funds (₹ Lakh)</th></tr></thead><tbody>{TABLE.map((r, idx) => <tr key={r.ngo} className={idx % 2 ? 'bg-gray-50' : ''}><td className="py-2">{r.ngo}</td><td>{r.projects}</td><td>{r.funds}</td></tr>)}</tbody><tfoot><tr><td className="py-2 font-medium">Total</td><td></td><td>{totalFunds}</td></tr></tfoot></table></div>
     </div>
   )
 }
 
-function Profile(){
-  const [company,setCompany]=useState({name:'Acme Corp', industry:'Manufacturing', location:'Mumbai, Maharashtra', website:'https://acme.example.com', contactPerson:'Rohit Sharma', email:'csr@acme.example.com', phone:'+91 98765 43210', budget:'₹ 1 - 5 Cr', logo:'/images/logo2.jpg'})
+function Profile() {
+  const [company, setCompany] = useState({ name: 'Acme Corp', industry: 'Manufacturing', location: 'Mumbai, Maharashtra', website: 'https://acme.example.com', contactPerson: 'Rohit Sharma', email: 'csr@acme.example.com', phone: '+91 98765 43210', budget: '₹ 1 - 5 Cr', logo: '/images/logo2.jpg' })
   return (
     <div className="space-y-6 px-8 pt-8 pb-10">
-      <Breadcrumb items={[{ label:'My Profile' }]} />
+      <Breadcrumb items={[{ label: 'My Profile' }]} />
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className="card-base p-6 lg:col-span-1">
           <div className="flex items-start gap-4">
-            <img src={company.logo} alt="logo" className="w-24 h-24 rounded-full object-cover border-4" style={{borderColor:'var(--border-color)'}} />
+            <img src={company.logo} alt="logo" className="w-24 h-24 rounded-full object-cover border-4" style={{ borderColor: 'var(--border-color)' }} />
             <div className="flex-1">
-              <div className="text-xl font-bold no-overflow" style={{color:'var(--text-primary-color)'}}>{company.name}</div>
-              <div className="text-sm" style={{color:'var(--text-secondary-color)'}}>{company.industry}</div>
-              <div className="text-sm mt-1" style={{color:'var(--text-secondary-color)'}}>{company.location}</div>
+              <div className="text-xl font-bold no-overflow" style={{ color: 'var(--text-primary-color)' }}>{company.name}</div>
+              <div className="text-sm" style={{ color: 'var(--text-secondary-color)' }}>{company.industry}</div>
+              <div className="text-sm mt-1" style={{ color: 'var(--text-secondary-color)' }}>{company.location}</div>
             </div>
             <button className="btn-primary-g px-3 py-2 rounded-md text-sm">Edit Profile</button>
           </div>
         </div>
         <div className="card-base p-6 lg:col-span-2">
-          <div className="font-semibold mb-4" style={{color:'var(--text-primary-color)'}}>Company Information</div>
+          <div className="font-semibold mb-4" style={{ color: 'var(--text-primary-color)' }}>Company Information</div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {[
-              {label:'Company Name', value:company.name, onChange:v=>setCompany({...company,name:v})},
-              {label:'Website', value:company.website, onChange:v=>setCompany({...company,website:v})},
-              {label:'Contact Person', value:company.contactPerson, onChange:v=>setCompany({...company,contactPerson:v})},
-              {label:'Email', value:company.email, onChange:v=>setCompany({...company,email:v})},
-              {label:'Phone', value:company.phone, onChange:v=>setCompany({...company,phone:v})},
-              {label:'CSR Budget', value:company.budget, onChange:v=>setCompany({...company,budget:v})},
-            ].map((f,i)=> (
+              { label: 'Company Name', value: company.name, onChange: v => setCompany({ ...company, name: v }) },
+              { label: 'Website', value: company.website, onChange: v => setCompany({ ...company, website: v }) },
+              { label: 'Contact Person', value: company.contactPerson, onChange: v => setCompany({ ...company, contactPerson: v }) },
+              { label: 'Email', value: company.email, onChange: v => setCompany({ ...company, email: v }) },
+              { label: 'Phone', value: company.phone, onChange: v => setCompany({ ...company, phone: v }) },
+              { label: 'CSR Budget', value: company.budget, onChange: v => setCompany({ ...company, budget: v }) },
+            ].map((f, i) => (
               <label key={i} className="block">
-                <span className="text-sm mb-1 block" style={{color:'var(--text-secondary-color)'}}>{f.label}</span>
-                <input className="w-full border rounded-lg px-3 py-2" style={{borderColor:'var(--border-color)'}} value={f.value} onChange={e=>f.onChange(e.target.value)} />
+                <span className="text-sm mb-1 block" style={{ color: 'var(--text-secondary-color)' }}>{f.label}</span>
+                <input className="w-full border rounded-lg px-3 py-2" style={{ borderColor: 'var(--border-color)' }} value={f.value} onChange={e => f.onChange(e.target.value)} />
               </label>
             ))}
           </div>
@@ -498,7 +483,7 @@ function Profile(){
 }
 
 // ---------- Routes wrapper ----------
-export default function DashboardBundle(){
+export default function DashboardBundle() {
   return (
     <Routes>
       <Route path="/dashboard" element={<DashboardLayout />}>
@@ -506,7 +491,10 @@ export default function DashboardBundle(){
         <Route path="discover" element={<Discover />} />
         <Route path="ngo/:ngoId" element={<NgoProfile />} />
         <Route path="requests" element={<Requests />} />
-        <Route path="reports" element={<Reports />} />
+        <Route
+          path="reports"
+          element={<CorporateReports projects={projects} transactions={transactions} donors={donors} />}
+        />
         <Route path="profile" element={<Profile />} />
       </Route>
     </Routes>

--- a/client/src/components/Corporate/CorporateDashboard.jsx
+++ b/client/src/components/Corporate/CorporateDashboard.jsx
@@ -1,5 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
+// at top, next to other imports
+import CorporateReports from "../Corporate/CorporateReports";
+
+// adjust the path to where the file actually lives relative to this file
+
 import {
     PieChart,
     Pie,
@@ -48,6 +53,9 @@ import {
     Calendar,
     Clock,
 } from "lucide-react";
+
+import { Bell } from "lucide-react";
+
 
 const FOCUS_AREA_OPTIONS = [
     { value: "education", label: "Education" },
@@ -197,9 +205,9 @@ const normalizeNgo = (item) => {
     const focusAreas = Array.isArray(focusAreasRaw)
         ? focusAreasRaw
         : String(focusAreasRaw ?? "")
-              .split(",")
-              .map((entry) => entry.trim())
-              .filter(Boolean);
+            .split(",")
+            .map((entry) => entry.trim())
+            .filter(Boolean);
     const normalizedFocusAreas = Array.from(
         new Set(
             focusAreas
@@ -333,6 +341,43 @@ export default function CorporateDashboard() {
     const [connSearchQuery, setConnSearchQuery] = useState("");
     const [connFocusFilter, setConnFocusFilter] = useState("");
     const [connVerifiedOnly, setConnVerifiedOnly] = useState(false);
+    // add in component body
+    const [bellOpen, setBellOpen] = useState(false);
+    const bellButtonRef = useRef(null);
+    const bellDropdownRef = useRef(null);
+
+    // sample notifications (replace with API data)
+    const [notifications] = useState([
+        // example items
+        // { id: 'n1', title: 'New request from Seva Foundation', body: 'Seva accepted your connection request.', time: '2h ago', from: 'Seva' }
+    ]);
+
+    const unreadCount = notifications.length; // change logic to count unread
+
+    // close on outside click / Esc
+    useEffect(() => {
+        function onDocClick(e) {
+            if (!bellOpen) return;
+            if (
+                bellDropdownRef.current &&
+                !bellDropdownRef.current.contains(e.target) &&
+                bellButtonRef.current &&
+                !bellButtonRef.current.contains(e.target)
+            ) {
+                setBellOpen(false);
+            }
+        }
+        function onKey(e) {
+            if (e.key === "Escape") setBellOpen(false);
+        }
+        document.addEventListener("click", onDocClick);
+        document.addEventListener("keydown", onKey);
+        return () => {
+            document.removeEventListener("click", onDocClick);
+            document.removeEventListener("keydown", onKey);
+        };
+    }, [bellOpen]);
+
     const connectionsSearchRef = useRef(null);
 
     const messageLoadTracker = useRef(new Set());
@@ -838,13 +883,12 @@ export default function CorporateDashboard() {
                                                 </div>
                                             </div>
                                             <span
-                                                className={`text-xs px-3 py-1 rounded-full font-medium ${
-                                                    item.status === "Accepted"
-                                                        ? "bg-emerald-100 text-emerald-600"
-                                                        : item.status === "Declined"
+                                                className={`text-xs px-3 py-1 rounded-full font-medium ${item.status === "Accepted"
+                                                    ? "bg-emerald-100 text-emerald-600"
+                                                    : item.status === "Declined"
                                                         ? "bg-rose-100 text-rose-600"
                                                         : "bg-amber-100 text-amber-600"
-                                                }`}
+                                                    }`}
                                             >
                                                 {item.status}
                                             </span>
@@ -1310,11 +1354,10 @@ export default function CorporateDashboard() {
                                 <button
                                     key={tab}
                                     onClick={() => setActiveTab(tab)}
-                                    className={`px-4 py-2 rounded-full text-sm font-medium transition-all ${
-                                        activeTab === tab
-                                            ? "bg-gradient-to-r from-indigo-500 to-purple-500 text-white shadow"
-                                            : "text-slate-500 hover:text-slate-700 hover:bg-slate-100"
-                                    }`}
+                                    className={`px-4 py-2 rounded-full text-sm font-medium transition-all ${activeTab === tab
+                                        ? "bg-gradient-to-r from-indigo-500 to-purple-500 text-white shadow"
+                                        : "text-slate-500 hover:text-slate-700 hover:bg-slate-100"
+                                        }`}
                                 >
                                     {tab}
                                 </button>
@@ -1502,9 +1545,8 @@ export default function CorporateDashboard() {
                                             />
                                             <div className="absolute inset-0 bg-gradient-to-t from-slate-900/45 via-slate-900/10 to-transparent" />
                                             <span
-                                                className={`absolute top-3 left-3 px-3 py-1 text-xs font-semibold rounded-full text-white shadow-sm ${
-                                                    ngo.verified ? "bg-emerald-500/90" : "bg-amber-500/90"
-                                                }`}
+                                                className={`absolute top-3 left-3 px-3 py-1 text-xs font-semibold rounded-full text-white shadow-sm ${ngo.verified ? "bg-emerald-500/90" : "bg-amber-500/90"
+                                                    }`}
                                             >
                                                 {ngo.verified ? "Verified" : "Unverified"}
                                             </span>
@@ -2188,8 +2230,8 @@ export default function CorporateDashboard() {
                                     ngo.focusAreas.filter(
                                         (area) => normalizeFocusAreaValue(area) !== "general"
                                     ).length === 0) && (
-                                    <option value="">Not specified</option>
-                                )}
+                                        <option value="">Not specified</option>
+                                    )}
                             </select>
                         </div>
 
@@ -2363,14 +2405,15 @@ export default function CorporateDashboard() {
     }
 
     const navItems = [
-        { id: "dashboard", label: "Dashboard", icon: Home },
-        { id: "analytics", label: "Analytics", icon: BarChart2 },
-        { id: "funding", label: "Funding", icon: HandCoins },
-        { id: "projects", label: "Projects", icon: FolderKanban },
-        { id: "connections", label: "Connections", icon: Users },
-        { id: "reports", label: "Reports", icon: FileText },
-        { id: "settings", label: "Settings", icon: SettingsIcon },
+        { id: 'dashboard', to: '/dashboard', icon: Home, label: 'Dashboard' },
+        { id: 'analytics', to: '/dashboard/analytics', icon: BarChart2, label: 'Analytics' },
+        { id: 'funding', to: '/dashboard/funding', icon: HandCoins, label: 'Funding' },
+        { id: 'projects', to: '/dashboard/projects', icon: FolderKanban, label: 'Projects' },
+        { id: 'connections', to: '/dashboard/connections', icon: Users, label: 'Connections' },
+        { id: 'reports', to: '/dashboard/reports', icon: FileText, label: 'Reports' }, // <- here
+        { id: 'settings', to: '/dashboard/settings', icon: SettingsIcon, label: 'Settings' },
     ];
+
 
     const navContent = {
         dashboard: <DashboardPage />,
@@ -2378,9 +2421,10 @@ export default function CorporateDashboard() {
         funding: <FundingPage />,
         projects: <ProjectsPage />,
         connections: <ConnectionsPage />,
-        reports: <ReportsPage />,
+        reports: <CorporateReports />, // << use this exact component
         settings: <SettingsPage />,
     };
+
 
     return (
         <div className="min-h-screen bg-gradient-to-br from-slate-50 to-indigo-50 flex text-slate-800 font-[Poppins]">
@@ -2392,9 +2436,8 @@ export default function CorporateDashboard() {
             )}
 
             <aside
-                className={`fixed top-0 left-0 h-full bg-white/95 backdrop-blur-md shadow-xl transform transition-transform duration-300 z-30 w-64 ${
-                    sidebarOpen ? "translate-x-0" : "-translate-x-full"
-                } ${sidebarPinned ? "lg:translate-x-0" : "lg:-translate-x-full"}`}
+                className={`fixed top-0 left-0 h-full bg-white/95 backdrop-blur-md shadow-xl transform transition-transform duration-300 z-30 w-64 ${sidebarOpen ? "translate-x-0" : "-translate-x-full"
+                    } ${sidebarPinned ? "lg:translate-x-0" : "lg:-translate-x-full"}`}
             >
                 <div className="p-6 border-b flex items-center justify-between">
                     <h2 className="text-2xl font-extrabold bg-gradient-to-r from-purple-500 to-indigo-600 bg-clip-text text-transparent">
@@ -2419,20 +2462,15 @@ export default function CorporateDashboard() {
                                     setActiveNav(item.id);
                                     setSidebarOpen(false);
                                 }}
-                                className={`w-full text-left flex items-center gap-3 p-3 rounded-lg ${
-                                    active
-                                        ? "bg-indigo-50 ring-1 ring-indigo-200"
-                                        : "hover:bg-slate-50"
-                                }`}
+                                className={`w-full text-left flex items-center gap-3 p-3 rounded-lg ${active ? "bg-indigo-50 ring-1 ring-indigo-200" : "hover:bg-slate-50"
+                                    }`}
                             >
                                 <Icon
                                     size={18}
                                     className={active ? "text-indigo-600" : "text-slate-500"}
                                 />
                                 <span
-                                    className={`font-medium ${
-                                        active ? "text-indigo-700" : "text-slate-600"
-                                    }`}
+                                    className={`font-medium ${active ? "text-indigo-700" : "text-slate-600"}`}
                                 >
                                     {item.label}
                                 </span>
@@ -2441,10 +2479,7 @@ export default function CorporateDashboard() {
                     })}
 
                     <div className="mt-6 border-t pt-4">
-                        <button 
-                            onClick={handleLogout}
-                            className="w-full flex items-center gap-3 p-3 rounded-lg text-red-600 hover:bg-red-50"
-                        >
+                        <button onClick={handleLogout} className="w-full flex items-center gap-3 p-3 rounded-lg text-red-600 hover:bg-red-50">
                             <LogOut size={18} />
                             <span className="font-medium">Logout</span>
                         </button>
@@ -2453,9 +2488,8 @@ export default function CorporateDashboard() {
             </aside>
 
             <div
-                className={`flex flex-col flex-1 min-w-0 transition-all duration-300 ${
-                    sidebarPinned ? "lg:ml-64" : "lg:ml-0"
-                }`}
+                className={`flex flex-col flex-1 min-w-0 transition-all duration-300 ${sidebarPinned ? "lg:ml-64" : "lg:ml-0"
+                    }`}
             >
                 <header className="flex items-center justify-between p-6 bg-white border-b shadow sticky top-0 z-10">
                     <div className="flex items-center gap-4">
@@ -2485,6 +2519,68 @@ export default function CorporateDashboard() {
                     </div>
 
                     <div className="flex items-center gap-4">
+
+                        {/* Notification bell + dropdown */}
+                        <div className="relative">
+                            <button
+                                onClick={() => setBellOpen((s) => !s)}
+                                aria-haspopup="true"
+                                aria-expanded={bellOpen ? "true" : "false"}
+                                className="p-2 rounded-full hover:bg-slate-100 border shadow-sm flex items-center justify-center"
+                                ref={bellButtonRef}
+                            >
+                                <Bell size={18} className="text-slate-700" />
+                                {/* unread badge (optional) */}
+                                {unreadCount > 0 && (
+                                    <span className="absolute -top-0.5 -right-0.5 h-3 w-3 rounded-full bg-red-500 border-2 border-white text-[10px] flex items-center justify-center text-white">
+                                        {/* small dot; if you want a number swap with {unreadCount} */}
+                                    </span>
+                                )}
+                            </button>
+
+                            {/* dropdown */}
+                            {bellOpen && (
+                                <div
+                                    role="dialog"
+                                    aria-label="Notifications"
+                                    className="absolute right-0 mt-2 w-80 bg-white rounded-xl shadow-lg border p-4 z-50"
+                                    ref={bellDropdownRef}
+                                    tabIndex={-1}
+                                >
+                                    <div className="flex items-center justify-between mb-3">
+                                        <h4 className="text-lg font-semibold text-slate-800">Messages</h4>
+                                        <button onClick={() => { setBellOpen(false); }} className="text-slate-400 hover:text-slate-600 text-sm">Close</button>
+                                    </div>
+
+                                    {/* list (replace with real messages) */}
+                                    {notifications.length === 0 ? (
+                                        <div className="py-6 text-center text-slate-500">No messages yet</div>
+                                    ) : (
+                                        <ul className="space-y-3 max-h-60 overflow-auto">
+                                            {notifications.map((n) => (
+                                                <li key={n.id} className="flex items-start gap-3">
+                                                    <div className="w-10 h-10 rounded-full bg-indigo-50 flex items-center justify-center text-indigo-600 font-medium">
+                                                        {n.from?.[0] ?? "M"}
+                                                    </div>
+                                                    <div className="flex-1">
+                                                        <div className="text-sm font-medium text-slate-800">{n.title}</div>
+                                                        <div className="text-xs text-slate-500 mt-1">{n.body}</div>
+                                                        <div className="text-[11px] text-slate-400 mt-1">{n.time}</div>
+                                                    </div>
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    )}
+
+                                    <div className="pt-3 mt-3 border-t text-right">
+                                        <button onClick={() => { /* navigate to full messages page if you have one */ setBellOpen(false); }} className="text-indigo-600 text-sm font-medium">
+                                            View all
+                                        </button>
+                                    </div>
+                                </div>
+                            )}
+                        </div>
+
                         <div className="text-right mr-4">
                             <p className="text-xs text-slate-500">CSR Budget</p>
                             <p className="text-sm font-medium text-slate-700">
@@ -2526,13 +2622,12 @@ export default function CorporateDashboard() {
 
             {alert && (
                 <div
-                    className={`fixed bottom-6 right-6 p-3 rounded shadow z-50 ${
-                        alert.kind === "success"
-                            ? "bg-green-50 text-green-700"
-                            : alert.kind === "error"
+                    className={`fixed bottom-6 right-6 p-3 rounded shadow z-50 ${alert.kind === "success"
+                        ? "bg-green-50 text-green-700"
+                        : alert.kind === "error"
                             ? "bg-red-50 text-red-700"
                             : "bg-indigo-50 text-indigo-700"
-                    }`}
+                        }`}
                 >
                     {alert.text}
                 </div>

--- a/client/src/components/Corporate/CorporateReports.jsx
+++ b/client/src/components/Corporate/CorporateReports.jsx
@@ -1,0 +1,359 @@
+// src/components/Corporate/CorporateReports.jsx
+import React, { useMemo, useState, useEffect } from "react";
+import { CSVLink } from "react-csv";
+import { Search, DownloadCloud, FileText, Eye } from "lucide-react";
+ // make sure this path/casing matches your project
+import Breadcrumb from '../shared/Breadcrumb';
+
+/**
+ * CorporateReports
+ * Props:
+ * - projects: array of project objects
+ * - transactions: array of transaction/history objects (donations/payments)
+ * - donors: array of donor totals { name, value }
+ * - showAlert: fn(message, kind) optional
+ */
+export default function CorporateReports({
+  projects = [],
+  transactions = [],
+  donors = [],
+  showAlert = () => {},
+}) {
+  const [tab, setTab] = useState("projects"); // projects | donations | donors
+  const [query, setQuery] = useState("");
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [rowsPerPage, setRowsPerPage] = useState(8);
+  const [page, setPage] = useState(1);
+  const [viewItem, setViewItem] = useState(null);
+
+  // helpers
+  const formatINR = (v) =>
+    `₹${Number(v || 0).toLocaleString("en-IN")}`;
+
+  const toISO = (d) => (d ? new Date(d).toISOString().slice(0, 10) : "");
+
+  const setRangeDays = (days) => {
+    const end = new Date();
+    const start = new Date();
+    start.setDate(end.getDate() - days);
+    setStartDate(toISO(start));
+    setEndDate(toISO(end));
+  };
+
+  // filtered datasets
+  const filteredProjects = useMemo(() => {
+    let list = projects.slice();
+    if (startDate) list = list.filter((p) => p.startDate && p.startDate >= startDate);
+    if (endDate) list = list.filter((p) => !p.endDate || p.endDate <= endDate);
+    if (query) {
+      const q = query.toLowerCase();
+      list = list.filter(
+        (p) =>
+          (p.name || "").toLowerCase().includes(q) ||
+          (p.partner || p.donor || "").toLowerCase().includes(q) ||
+          (p.location || "").toLowerCase().includes(q)
+      );
+    }
+    return list;
+  }, [projects, startDate, endDate, query]);
+
+  const donations = useMemo(() => transactions.filter((t) => (t.type || t.action || "").toLowerCase() === "donation"), [transactions]);
+
+  const filteredDonations = useMemo(() => {
+    let list = donations.slice();
+    if (startDate) list = list.filter((d) => d.date && d.date >= startDate);
+    if (endDate) list = list.filter((d) => d.date && d.date <= endDate);
+    if (query) {
+      const q = query.toLowerCase();
+      list = list.filter((d) => (d.company || d.donor || "").toLowerCase().includes(q) || (d.note || "").toLowerCase().includes(q));
+    }
+    return list;
+  }, [donations, startDate, endDate, query]);
+
+  const filteredDonors = useMemo(() => {
+    let list = donors.slice();
+    if (query) {
+      const q = query.toLowerCase();
+      list = list.filter((d) => (d.name || "").toLowerCase().includes(q));
+    }
+    return list;
+  }, [donors, query]);
+
+  // pagination helpers
+  const pageCount = (len) => Math.max(1, Math.ceil(len / rowsPerPage));
+  const paginated = (arr) => {
+    const start = (page - 1) * rowsPerPage;
+    return arr.slice(start, start + rowsPerPage);
+  };
+
+  useEffect(() => {
+    setPage(1);
+  }, [tab, query, startDate, endDate, rowsPerPage]);
+
+  // CSV exports
+  const csvProjects = useMemo(() => [
+    ["Project name", "Partner/Donor", "Funds", "Status", "Start", "End", "Beneficiaries"],
+    ...projects.map((p) => [p.name, p.partner ?? p.donor ?? "", p.fundsDisplay ?? p.funds ?? "", p.status ?? "", p.startDate ?? "", p.endDate ?? "", p.beneficiaries ?? ""])
+  ], [projects]);
+
+  const csvDonations = useMemo(() => [
+    ["Date", "Donor", "Amount", "Note"],
+    ...donations.map((d) => [d.date || "", d.company || d.donor || "", d.amount || "", d.note || ""])
+  ], [donations]);
+
+  const csvDonors = useMemo(() => [
+    ["Donor", "TotalFunds"],
+    ...donors.map((d) => [d.name, d.value])
+  ], [donors]);
+
+  const printReport = () => window.print();
+
+  return (
+    <div className="bg-white rounded-2xl shadow-lg p-6 border border-indigo-50 space-y-6">
+      <Breadcrumb items={[{ label: "Reports" }]} />
+
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <h2 className="text-xl font-semibold text-slate-900">Reports</h2>
+          <p className="text-sm text-slate-500">Generate and export reports for corporate projects, donors and donations</p>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <div className="flex items-center bg-slate-100 rounded px-3 py-2 gap-2">
+            <Search size={16} className="text-slate-500" />
+            <input
+              className="bg-transparent outline-none text-sm"
+              placeholder="Search..."
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <input type="date" value={startDate} onChange={(e) => setStartDate(e.target.value)} className="border rounded px-2 py-1 text-sm" />
+            <input type="date" value={endDate} onChange={(e) => setEndDate(e.target.value)} className="border rounded px-2 py-1 text-sm" />
+            <button onClick={() => { setStartDate(""); setEndDate(""); }} className="px-2 py-1 bg-slate-100 rounded text-sm">Reset</button>
+            <div className="flex items-center gap-1">
+              <button onClick={() => setRangeDays(30)} className="px-2 py-1 text-xs rounded bg-indigo-50">30d</button>
+              <button onClick={() => setRangeDays(90)} className="px-2 py-1 text-xs rounded bg-indigo-50">90d</button>
+              <button onClick={() => { setStartDate(""); setEndDate(""); }} className="px-2 py-1 text-xs rounded bg-indigo-50">All</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* tabs + actions */}
+      <div className="flex items-center gap-2 border-b pb-3">
+        <button onClick={() => setTab("projects")} className={`px-3 py-2 rounded ${tab === "projects" ? "bg-indigo-50" : "hover:bg-slate-50"}`}>Projects</button>
+        <button onClick={() => setTab("donations")} className={`px-3 py-2 rounded ${tab === "donations" ? "bg-indigo-50" : "hover:bg-slate-50"}`}>Donations</button>
+        <button onClick={() => setTab("donors")} className={`px-3 py-2 rounded ${tab === "donors" ? "bg-indigo-50" : "hover:bg-slate-50"}`}>Donors</button>
+
+        <div className="ml-auto flex items-center gap-2">
+          <CSVLink
+            data={tab === "projects" ? csvProjects : tab === "donations" ? csvDonations : csvDonors}
+            filename={`corporate_reports_${tab}_${new Date().toISOString().slice(0,10)}.csv`}
+            className="px-3 py-2 bg-indigo-600 text-white rounded flex items-center gap-2 text-sm"
+          >
+            <DownloadCloud size={16} /> Export CSV
+          </CSVLink>
+
+          <button onClick={() => printReport()} className="px-3 py-2 bg-slate-100 rounded text-sm flex items-center gap-2">
+            <FileText size={16} /> Print
+          </button>
+        </div>
+      </div>
+
+      {/* table area */}
+      <div>
+        {tab === "projects" && (
+          <div>
+            <div className="overflow-auto rounded border">
+              <table className="min-w-full divide-y">
+                <thead className="bg-white">
+                  <tr>
+                    <th className="px-4 py-3 text-left text-sm font-medium">Project</th>
+                    <th className="px-4 py-3 text-left text-sm font-medium">Partner</th>
+                    <th className="px-4 py-3 text-left text-sm font-medium">Funds</th>
+                    <th className="px-4 py-3 text-left text-sm font-medium">Status</th>
+                    <th className="px-4 py-3 text-left text-sm font-medium">Dates</th>
+                    <th className="px-4 py-3 text-right text-sm font-medium">Actions</th>
+                  </tr>
+                </thead>
+                <tbody className="bg-white divide-y">
+                  {paginated(filteredProjects).map((p) => (
+                    <tr key={p.id}>
+                      <td className="px-4 py-3">{p.name}</td>
+                      <td className="px-4 py-3">{p.partner ?? p.donor ?? "-"}</td>
+                      <td className="px-4 py-3">{p.fundsDisplay ?? formatINR(p.funds)}</td>
+                      <td className="px-4 py-3">{p.status ?? "-"}</td>
+                      <td className="px-4 py-3">{p.startDate ?? "-"} {p.endDate ? `– ${p.endDate}` : ""}</td>
+                      <td className="px-4 py-3 text-right">
+                        <button onClick={() => setViewItem({ type: "project", item: p })} className="px-2 py-1 bg-slate-100 rounded text-sm flex items-center gap-2"><Eye size={14} /> View</button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {/* pagination */}
+            <div className="flex items-center justify-between mt-3">
+              <div className="text-sm text-slate-500">Showing {Math.min(filteredProjects.length, page * rowsPerPage)} of {filteredProjects.length}</div>
+              <div className="flex items-center gap-2">
+                <select value={rowsPerPage} onChange={(e) => setRowsPerPage(Number(e.target.value))} className="border rounded px-2 py-1 text-sm">
+                  <option value={5}>5</option>
+                  <option value={8}>8</option>
+                  <option value={12}>12</option>
+                </select>
+                <button disabled={page === 1} onClick={() => setPage((p) => Math.max(1, p - 1))} className="px-2 py-1 border rounded">Prev</button>
+                <div className="px-2 py-1 rounded bg-slate-50 text-sm">Page {page}/{pageCount(filteredProjects.length)}</div>
+                <button disabled={page >= pageCount(filteredProjects.length)} onClick={() => setPage((p) => Math.min(pageCount(filteredProjects.length), p + 1))} className="px-2 py-1 border rounded">Next</button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {tab === "donations" && (
+          <div>
+            <div className="overflow-auto rounded border">
+              <table className="min-w-full divide-y">
+                <thead className="bg-white">
+                  <tr>
+                    <th className="px-4 py-3 text-left text-sm font-medium">Date</th>
+                    <th className="px-4 py-3 text-left text-sm font-medium">Donor</th>
+                    <th className="px-4 py-3 text-left text-sm font-medium">Amount</th>
+                    <th className="px-4 py-3 text-left text-sm font-medium">Note</th>
+                    <th className="px-4 py-3 text-right text-sm font-medium">Actions</th>
+                  </tr>
+                </thead>
+                <tbody className="bg-white divide-y">
+                  {paginated(filteredDonations).map((d) => (
+                    <tr key={d.id}>
+                      <td className="px-4 py-3">{d.date}</td>
+                      <td className="px-4 py-3">{d.company ?? d.donor}</td>
+                      <td className="px-4 py-3">{formatINR(d.amount)}</td>
+                      <td className="px-4 py-3">{d.note}</td>
+                      <td className="px-4 py-3 text-right">
+                        <button onClick={() => setViewItem({ type: "donation", item: d })} className="px-2 py-1 bg-slate-100 rounded text-sm flex items-center gap-2"><Eye size={14} /> View</button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="flex items-center justify-between mt-3">
+              <div className="text-sm text-slate-500">Showing {Math.min(filteredDonations.length, page * rowsPerPage)} of {filteredDonations.length}</div>
+              <div className="flex items-center gap-2">
+                <select value={rowsPerPage} onChange={(e) => setRowsPerPage(Number(e.target.value))} className="border rounded px-2 py-1 text-sm">
+                  <option value={5}>5</option>
+                  <option value={8}>8</option>
+                  <option value={12}>12</option>
+                </select>
+                <button disabled={page === 1} onClick={() => setPage((p) => Math.max(1, p - 1))} className="px-2 py-1 border rounded">Prev</button>
+                <div className="px-2 py-1 rounded bg-slate-50 text-sm">Page {page}/{pageCount(filteredDonations.length)}</div>
+                <button disabled={page >= pageCount(filteredDonations.length)} onClick={() => setPage((p) => Math.min(pageCount(filteredDonations.length), p + 1))} className="px-2 py-1 border rounded">Next</button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {tab === "donors" && (
+          <div>
+            <div className="overflow-auto rounded border">
+              <table className="min-w-full divide-y">
+                <thead className="bg-white">
+                  <tr>
+                    <th className="px-4 py-3 text-left text-sm font-medium">Donor</th>
+                    <th className="px-4 py-3 text-left text-sm font-medium">Total</th>
+                  </tr>
+                </thead>
+                <tbody className="bg-white divide-y">
+                  {paginated(filteredDonors).map((d) => (
+                    <tr key={d.name}>
+                      <td className="px-4 py-3">{d.name}</td>
+                      <td className="px-4 py-3">{formatINR(d.value)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="flex items-center justify-between mt-3">
+              <div className="text-sm text-slate-500">Showing {Math.min(filteredDonors.length, page * rowsPerPage)} of {filteredDonors.length}</div>
+              <div className="flex items-center gap-2">
+                <select value={rowsPerPage} onChange={(e) => setRowsPerPage(Number(e.target.value))} className="border rounded px-2 py-1 text-sm">
+                  <option value={5}>5</option>
+                  <option value={8}>8</option>
+                  <option value={12}>12</option>
+                </select>
+                <button disabled={page === 1} onClick={() => setPage((p) => Math.max(1, p - 1))} className="px-2 py-1 border rounded">Prev</button>
+                <div className="px-2 py-1 rounded bg-slate-50 text-sm">Page {page}/{pageCount(filteredDonors.length)}</div>
+                <button disabled={page >= pageCount(filteredDonors.length)} onClick={() => setPage((p) => Math.min(pageCount(filteredDonors.length), p + 1))} className="px-2 py-1 border rounded">Next</button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* View modal */}
+      {viewItem && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+          <div className="absolute inset-0 bg-black/30" onClick={() => setViewItem(null)} />
+          <div className="relative bg-white rounded-xl shadow-lg w-full max-w-2xl p-6 z-10">
+            <div className="flex items-start justify-between">
+              <h3 className="text-lg font-semibold">{viewItem.type === "project" ? viewItem.item.name : (viewItem.item.company || viewItem.item.donor)}</h3>
+              <button onClick={() => setViewItem(null)} className="text-slate-500">Close</button>
+            </div>
+
+            <div className="mt-4 grid grid-cols-2 gap-4">
+              {viewItem.type === "project" ? (
+                <>
+                  <div>
+                    <p className="text-xs text-slate-500">Partner</p>
+                    <p className="font-medium">{viewItem.item.partner ?? viewItem.item.donor}</p>
+
+                    <p className="text-xs text-slate-500 mt-3">Beneficiaries</p>
+                    <p className="font-medium">{viewItem.item.beneficiaries}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-slate-500">Funds</p>
+                    <p className="font-medium">{viewItem.item.fundsDisplay ?? formatINR(viewItem.item.funds)}</p>
+
+                    <p className="text-xs text-slate-500 mt-3">Status</p>
+                    <p className="font-medium">{viewItem.item.status}</p>
+                  </div>
+                  <div className="col-span-2">
+                    <p className="text-xs text-slate-500">Description</p>
+                    <p className="text-sm">{viewItem.item.description}</p>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div>
+                    <p className="text-xs text-slate-500">Date</p>
+                    <p className="font-medium">{viewItem.item.date}</p>
+
+                    <p className="text-xs text-slate-500 mt-3">Amount</p>
+                    <p className="font-medium">{formatINR(viewItem.item.amount)}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-slate-500">Note</p>
+                    <p className="text-sm">{viewItem.item.note}</p>
+                    <p className="text-xs text-slate-500 mt-3">Recorded ID</p>
+                    <p className="text-sm text-slate-400">{viewItem.item.id}</p>
+                  </div>
+                </>
+              )}
+            </div>
+
+            <div className="mt-6 text-right">
+              <button onClick={() => setViewItem(null)} className="px-3 py-2 bg-slate-100 rounded">Close</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/shared/Breadcrumb.jsx
+++ b/client/src/components/shared/Breadcrumb.jsx
@@ -1,0 +1,21 @@
+// src/components/shared/Breadcrumb.jsx
+import React from "react";
+import { Link } from "react-router-dom";
+
+export default function Breadcrumb({ items = [] }) {
+  return (
+    <nav className="flex items-center space-x-2 text-sm mb-6">
+      <Link to="/dashboard" className="text-gray-500 hover:text-gray-700">Company Portal</Link>
+      {items.map((item, i)=> (
+        <div key={i} className="flex items-center space-x-2">
+          <span className="text-gray-400">/</span>
+          {item.href ? (
+            <Link to={item.href} className="text-gray-500 hover:text-gray-700">{item.label}</Link>
+          ) : (
+            <span className="font-medium" style={{ color: "var(--text-primary-color)" }}>{item.label}</span>
+          )}
+        </div>
+      ))}
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
This PR adds a Corporate Reports page (CorporateReports.jsx) styled to match the existing Corporate dashboard UI and includes a notification bell UI (with popup) on the corporate reports page similar to the NGO dashboard. It also fixes related layout issues and imports.

## Changes
- Added `client/src/components/Corporate/CorporateReports.jsx` — corporate reports UI (projects / donations / donors tabs, CSV export, print).
- Integrated `CorporateReports` into `CorporateDashboard` routes and nav.
- Added notification bell component in the header (popup, unread count).
- Minor CSS / class renames to keep look consistent with other corporate pages.
- Fixed import paths and removed duplicate/incorrect imports that caused the `Identifier 'useState' has already been declared` error.

## Why
We needed a stripped-down corporate-facing reports page with the same aesthetic as the corporate dashboard and a notification bell for alerts. This keeps parity between NGO and corporate experiences.

## How to test (manual)
1. Checkout branch:
   ```bash
   git checkout feat/corporate-reports-bell-fix
   npm install    # if new deps added
   npm run dev
